### PR TITLE
A: Bio and Social Links

### DIFF
--- a/app/Http/Controllers/UserInformationController.php
+++ b/app/Http/Controllers/UserInformationController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use App\Models\UserInformation;
 use App\Models\User;
+use App\Models\SocialLink;
 use App\Models\DisplayPicture;
 
 // Requests
@@ -77,6 +78,7 @@ class UserInformationController extends Controller
                 'message' => 'Successfully uploaded picture.'
             ], 200);
         }
+        //END Display Picture
 
         // Checks if username, role and/or email are blank.
         if(!empty($request->username) || !empty($request->email)) 
@@ -95,6 +97,19 @@ class UserInformationController extends Controller
             return response()->json([
                 'message' => 'User information not found.'
             ], 404);
+        }
+
+        if(!empty($request->social_medias) && !empty($request->social_links))
+        {
+            for($i=0; count($request->social_medias) > $i; $i++)
+            {
+                $userSocialLink = new SocialLink([
+                    'social_media' => $request->social_medias[$i],
+                    'social_link' => $request->social_links[$i]
+                ]);
+                $userSocialLink->user()->associate($user);
+                $userSocialLink->save();
+            }
         }
 
         if($user->hasRole('manufacturer'))

--- a/app/Http/Controllers/UserInformationController.php
+++ b/app/Http/Controllers/UserInformationController.php
@@ -103,12 +103,16 @@ class UserInformationController extends Controller
         {
             for($i=0; count($request->social_medias) > $i; $i++)
             {
-                $userSocialLink = new SocialLink([
-                    'social_media' => $request->social_medias[$i],
-                    'social_link' => $request->social_links[$i]
-                ]);
-                $userSocialLink->user()->associate($user);
-                $userSocialLink->save();
+                $duplicateChecker = $this->checkDuplicateSocialLink($request->social_links[$i]);
+                if(!$duplicateChecker)
+                {
+                    $userSocialLink = new SocialLink([
+                        'social_media' => $request->social_medias[$i],
+                        'social_link' => $request->social_links[$i]
+                    ]);
+                    $userSocialLink->user()->associate($user);
+                    $userSocialLink->save();
+                }
             }
         }
 
@@ -145,5 +149,18 @@ class UserInformationController extends Controller
         return response()->json([
             'message' => 'Successfully updated user information.'
         ], 201);
+    }
+
+    protected function checkDuplicateSocialLink(string $socialLink)
+    {
+        $links = auth()->user()->social_link;
+        foreach($links as $link)
+        {
+            if($link->social_link === $socialLink)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/Http/Requests/UserRequest/UpdateRequest.php
+++ b/app/Http/Requests/UserRequest/UpdateRequest.php
@@ -33,6 +33,11 @@ class UpdateRequest extends FormRequest
     {
         return [
             'display_picture' => 'image|mimes:jpeg,jpg,png,gif|nullable|max:204800',
+            'bio' => 'nullable|string',
+            'social_medias' => 'nullable|array',
+            'social_medias.*' => 'nullable|string',
+            'social_links' => 'nullable|array',
+            'social_links.*' => 'nullable|string|distinct',
             'username' => 'nullable|string',
             'email' => 'nullable|string',
             'first_name' => 'nullable|string',

--- a/app/Http/Requests/UserRequest/UpdateRequest.php
+++ b/app/Http/Requests/UserRequest/UpdateRequest.php
@@ -37,7 +37,7 @@ class UpdateRequest extends FormRequest
             'social_medias' => 'nullable|array',
             'social_medias.*' => 'nullable|string',
             'social_links' => 'nullable|array',
-            'social_links.*' => 'nullable|string|distinct',
+            'social_links.*' => 'nullable|string|distinct:strict',
             'username' => 'nullable|string',
             'email' => 'nullable|string',
             'first_name' => 'nullable|string',

--- a/app/Models/SocialLink.php
+++ b/app/Models/SocialLink.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
+
+class SocialLink extends Model
+{
+    use HasFactory;
+    protected $table = 'social_links';
+    
+    protected $fillable = [
+        'social_link',
+        'social_media'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Spatie\Permission\Traits\HasRoles;
 use App\Models\Designer\Design;
 use App\Models\BuyerQueue;
 use App\Models\DisplayPicture;
+use App\Models\SocialLink;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -64,6 +65,11 @@ class User extends Authenticatable implements MustVerifyEmail
     public function displayPicture()
     {
         return $this->hasMany(DisplayPicture::class, 'user_id');
+    }
+
+    public function social_link()
+    {
+        return $this->hasMany(SocialLink::class, 'user_id');
     }
 
     public function user_information()

--- a/database/migrations/2021_04_14_155223_create_social_links_table.php
+++ b/database/migrations/2021_04_14_155223_create_social_links_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSocialLinksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('social_links', function (Blueprint $table) {
+            $table->id();
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreignId('user_id')->onDelete('cascade');
+            $table->string('social_link');
+            $table->string('social_media');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('social_links');
+    }
+}


### PR DESCRIPTION
_api/auth/update-user-information_ can now add an array of social links.

The api needs 2 keynames/fields when adding a new social link: 
"**social_medias**" is the name of the social media i.e. Facebook, Twitter.
"**social_links**" is the link connected to the user's profile.
In addition, the api also accepts the "**bio**" keyname/field. 

These 3 new keynames/fields are nullable.